### PR TITLE
Make ovld even faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,16 +188,17 @@ assert Two().f("s") == "a string"
 
 # Benchmarks
 
-`ovld` is pretty fast: the overhead is comparable to `isinstance` or `match`, and only 2-3x slower when dispatching on `Literal` types. Compared to other multiple dispatch libraries, it is 1.5x to 100x faster.
+`ovld` is pretty fast: the overhead is comparable to `isinstance` or `match`, and only 2-3x slower when dispatching on `Literal` types. Compared to other multiple dispatch libraries, it has 1.5x to 100x less overhead.
 
 Time relative to the fastest implementation (1.00) (lower is better).
 
-| Bench | custom | [ovld](https://github.com/breuleux/ovld) | [plum](https://github.com/beartype/plum) | [multim](https://github.com/coady/multimethod) | [multid](https://github.com/mrocklin/multipledispatch/) | [runtype](https://github.com/erezsh/runtype) | [fastcore](https://github.com/fastai/fastcore) | [singled](https://docs.python.org/3/library/functools.html#functools.singledispatch) |
+| Benchmark | custom | [ovld](https://github.com/breuleux/ovld) | [plum](https://github.com/beartype/plum) | [multim](https://github.com/coady/multimethod) | [multid](https://github.com/mrocklin/multipledispatch/) | [runtype](https://github.com/erezsh/runtype) | [fastcore](https://github.com/fastai/fastcore) | [sd](https://docs.python.org/3/library/functools.html#functools.singledispatch) |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-|[trivial](https://github.com/breuleux/ovld/tree/master/benchmarks/test_trivial.py)|1.14|1.00|2.53|3.64|1.61|1.86|41.31|1.54|
-|[add](https://github.com/breuleux/ovld/tree/master/benchmarks/test_add.py)|1.01|1.00|3.46|4.83|2.21|2.66|56.08|x|
-|[multer](https://github.com/breuleux/ovld/tree/master/benchmarks/test_multer.py)|1.00|1.06|9.79|4.11|7.19|1.89|40.37|6.34|
-|[ast](https://github.com/breuleux/ovld/tree/master/benchmarks/test_ast.py)|1.00|1.06|23.07|3.04|1.68|1.87|29.11|1.63|
-|[calc](https://github.com/breuleux/ovld/tree/master/benchmarks/test_calc.py)|1.00|1.96|80.00|43.21|x|x|x|x|
-|[fib](https://github.com/breuleux/ovld/tree/master/benchmarks/test_fib.py)|1.00|3.58|438.97|123.58|x|x|x|x|
-|[tweak](https://github.com/breuleux/ovld/tree/master/benchmarks/test_tweaknum.py)|1.00|2.59|x|x|x|x|x|x|
+|[trivial](https://github.com/breuleux/ovld/tree/master/benchmarks/test_trivial.py)|1.45|1.00|3.32|4.63|2.04|2.41|51.93|1.91|
+|[multer](https://github.com/breuleux/ovld/tree/master/benchmarks/test_multer.py)|1.13|1.00|11.05|4.53|8.31|2.19|46.74|7.32|
+|[add](https://github.com/breuleux/ovld/tree/master/benchmarks/test_add.py)|1.08|1.00|3.73|5.21|2.37|2.79|59.31|x|
+|[ast](https://github.com/breuleux/ovld/tree/master/benchmarks/test_ast.py)|1.00|1.08|23.14|3.09|1.68|1.91|28.39|1.66|
+|[calc](https://github.com/breuleux/ovld/tree/master/benchmarks/test_calc.py)|1.00|1.23|54.61|29.32|x|x|x|x|
+|[regexp](https://github.com/breuleux/ovld/tree/master/benchmarks/test_regexp.py)|1.00|1.87|19.18|x|x|x|x|x|
+|[fib](https://github.com/breuleux/ovld/tree/master/benchmarks/test_fib.py)|1.00|3.30|444.31|125.77|x|x|x|x|
+|[tweaknum](https://github.com/breuleux/ovld/tree/master/benchmarks/test_tweaknum.py)|1.00|2.09|x|x|x|x|x|x|

--- a/benchmarks/test_calc.py
+++ b/benchmarks/test_calc.py
@@ -115,7 +115,7 @@ ops = {
 def calc_dict(expr):
     if isinstance(expr, tuple):
         return ops[expr[0]](*expr[1:])
-    elif isinstance(expr, (int, float)):
+    elif isinstance(expr, Number):
         return expr
 
 

--- a/benchmarks/test_multer.py
+++ b/benchmarks/test_multer.py
@@ -148,7 +148,7 @@ def make_test(cls):
 
 
 test_multer_ovld = make_test(make_multer(ovld_dispatch))
-test_multer_ovld_recurse = make_test(OvldRecurseMulter)
+test_multer_recurse = make_test(OvldRecurseMulter)
 test_multer_plum = make_test(make_multer(plum_dispatch))
 test_multer_multimethod = make_test(make_multer(multimethod_dispatch))
 test_multer_singledispatch = make_test(SingleDispatchMulter)

--- a/benchmarks/test_regexp.py
+++ b/benchmarks/test_regexp.py
@@ -1,0 +1,96 @@
+import re
+
+import pytest
+
+from ovld.dependent import Regexp
+
+from .common import ovld_dispatch, plum_dispatch
+
+###############################
+# multiple dispatch libraries #
+###############################
+
+
+def make_regexp(dispatch):
+    @dispatch
+    def regexp(x: Regexp[r"^a"]):
+        return "one"
+
+    @dispatch
+    def regexp(x: Regexp[r"^[bcd]"]):
+        return "two"
+
+    @dispatch
+    def regexp(x: Regexp[r"end$"]):
+        return "three"
+
+    return regexp
+
+
+##############
+# isinstance #
+##############
+
+
+def regexp_search(x):
+    if re.search(string=x, pattern=r"^a"):
+        return "one"
+    if re.search(string=x, pattern=r"^[bcd]"):
+        return "two"
+    if re.search(string=x, pattern=r"end$"):
+        return "three"
+
+
+re1 = re.compile(r"^a")
+re2 = re.compile(r"^[bcd]")
+re3 = re.compile(r"end$")
+
+
+def regexp_compiled(x):
+    if re1.search(x):
+        return "one"
+    if re2.search(x):
+        return "two"
+    if re3.search(x):
+        return "three"
+
+
+def regexp_compiled_nonexclusive(x):
+    r1 = bool(re1.search(x))
+    r2 = bool(re2.search(x))
+    r3 = bool(re3.search(x))
+    if r1:
+        return "one"
+    if r2:
+        return "two"
+    if r3:
+        return "three"
+
+
+####################
+# Test definitions #
+####################
+
+
+def make_test(fn):
+    @pytest.mark.benchmark(group="regexp")
+    def test(benchmark):
+        def run():
+            return [
+                fn("allo"),
+                fn("canada"),
+                fn("the end"),
+            ]
+
+        result = benchmark(run)
+        assert result == ["one", "two", "three"]
+
+    return test
+
+
+test_regexp_ovld = make_test(make_regexp(ovld_dispatch))
+test_regexp_plum = make_test(make_regexp(plum_dispatch))
+
+test_regexp_custom_search = make_test(regexp_search)
+test_regexp_custom_compiled = make_test(regexp_compiled)
+# test_regexp_custom_compiled_nx = make_test(regexp_compiled_nonexclusive)

--- a/docs/compare.md
+++ b/docs/compare.md
@@ -3,7 +3,7 @@
 
 ## Unique features
 
-Current as of September 2024: I have investigated and benchmarked six other multiple/single dispatch libraries. Performance-wise, `ovld` is faster than all of them, ranging from 1.5x faster to 100x faster. Feature-wise, `ovld` is among the most featureful. Some features I could not find elsewhere:
+Current as of October 2024: I have investigated and benchmarked six other multiple/single dispatch libraries. Performance-wise, `ovld` is faster than all of them, ranging from 1.5x to 100x less overhead. Feature-wise, `ovld` is among the most featureful. Some features I could not find elsewhere:
 
 * Support for [keyword arguments](usage.md#keyword-arguments).
 * [Variants](usage.md#variants), especially working with recursion.
@@ -27,10 +27,11 @@ Current as of September 2024: I have investigated and benchmarked six other mult
 Applicable libraries were tested on the following problems:
 
 * [trivial](https://github.com/breuleux/ovld/tree/master/benchmarks/test_trivial.py): Basic single dispatch test with a bunch of types.
-* [add](https://github.com/breuleux/ovld/tree/master/benchmarks/test_add.py): Recursively add lists and dictionaries element-wise.
 * [multer](https://github.com/breuleux/ovld/tree/master/benchmarks/test_multer.py): Recursively multiply lists and dictionaries element-wise by a number, but using a class. This tests dispatch on methods.
+* [add](https://github.com/breuleux/ovld/tree/master/benchmarks/test_add.py): Recursively add lists and dictionaries element-wise.
 * [ast](https://github.com/breuleux/ovld/tree/master/benchmarks/test_ast.py): Simple transform on a Python AST.
 * [calc](https://github.com/breuleux/ovld/tree/master/benchmarks/test_calc.py): Calculator implementation. Dispatches using `op: Literal[<opname>]`.
+* [regexp](https://github.com/breuleux/ovld/tree/master/benchmarks/test_regexp.py): Dispatch based on a regular expression (`ovld.dependent.Regexp[<regex>]`).
 * [fib](https://github.com/breuleux/ovld/tree/master/benchmarks/test_fib.py): Fibonacci numbers. The base cases are implemented by dispatching on `n: Literal[0]` and `n: Literal[1]`.
 * [tweaknum](https://github.com/breuleux/ovld/tree/master/benchmarks/test_tweaknum.py): Dispatching on keyword arguments.
 
@@ -39,21 +40,21 @@ Applicable libraries were tested on the following problems:
 
 Time relative to the fastest implementation (1.00) (lower is better). Python version: 3.12.4
 
-The **custom** column represents custom implementations using isinstance, match, a dispatch dict, etc. They are usually the fastest, but that should not be surprising. ovld's performance ranges from 1.1x faster to 3.7x slower.
+The **custom** column represents custom implementations using isinstance, match, a dispatch dict, etc. They are usually the fastest, but that should not be surprising. ovld's performance ranges from 1.5x faster to 3.3x slower.
 
-| Bench | custom | [ovld](https://github.com/breuleux/ovld) | [plum](https://github.com/beartype/plum) | [multim](https://github.com/coady/multimethod) | [multid](https://github.com/mrocklin/multipledispatch/) | [runtype](https://github.com/erezsh/runtype) | [fastcore](https://github.com/fastai/fastcore) | [singled](https://docs.python.org/3/library/functools.html#functools.singledispatch) |
+| Benchmark | custom | [ovld](https://github.com/breuleux/ovld) | [plum](https://github.com/beartype/plum) | [multim](https://github.com/coady/multimethod) | [multid](https://github.com/mrocklin/multipledispatch/) | [runtype](https://github.com/erezsh/runtype) | [fastcore](https://github.com/fastai/fastcore) | [sd](https://docs.python.org/3/library/functools.html#functools.singledispatch) |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-|[trivial](https://github.com/breuleux/ovld/tree/master/benchmarks/test_trivial.py)|1.14|1.00|2.53|3.64|1.61|1.86|41.31|1.54|
-|[add](https://github.com/breuleux/ovld/tree/master/benchmarks/test_add.py)|1.01|1.00|3.46|4.83|2.21|2.66|56.08|x|
-|[multer](https://github.com/breuleux/ovld/tree/master/benchmarks/test_multer.py)|1.00|1.06|9.79|4.11|7.19|1.89|40.37|6.34|
-|[ast](https://github.com/breuleux/ovld/tree/master/benchmarks/test_ast.py)|1.00|1.06|23.07|3.04|1.68|1.87|29.11|1.63|
-|[calc](https://github.com/breuleux/ovld/tree/master/benchmarks/test_calc.py)|1.00|1.96|80.00|43.21|x|x|x|x|
-|[fib](https://github.com/breuleux/ovld/tree/master/benchmarks/test_fib.py)|1.00|3.58|438.97|123.58|x|x|x|x|
-|[tweak](https://github.com/breuleux/ovld/tree/master/benchmarks/test_tweaknum.py)|1.00|2.59|x|x|x|x|x|x|
-
+|[trivial](https://github.com/breuleux/ovld/tree/master/benchmarks/test_trivial.py)|1.45|1.00|3.32|4.63|2.04|2.41|51.93|1.91|
+|[multer](https://github.com/breuleux/ovld/tree/master/benchmarks/test_multer.py)|1.13|1.00|11.05|4.53|8.31|2.19|46.74|7.32|
+|[add](https://github.com/breuleux/ovld/tree/master/benchmarks/test_add.py)|1.08|1.00|3.73|5.21|2.37|2.79|59.31|x|
+|[ast](https://github.com/breuleux/ovld/tree/master/benchmarks/test_ast.py)|1.00|1.08|23.14|3.09|1.68|1.91|28.39|1.66|
+|[calc](https://github.com/breuleux/ovld/tree/master/benchmarks/test_calc.py)|1.00|1.23|54.61|29.32|x|x|x|x|
+|[regexp](https://github.com/breuleux/ovld/tree/master/benchmarks/test_regexp.py)|1.00|1.87|19.18|x|x|x|x|x|
+|[fib](https://github.com/breuleux/ovld/tree/master/benchmarks/test_fib.py)|1.00|3.30|444.31|125.77|x|x|x|x|
+|[tweaknum](https://github.com/breuleux/ovld/tree/master/benchmarks/test_tweaknum.py)|1.00|2.09|x|x|x|x|x|x|
 
 ## Comments
 
 A big part of ovld's advantage comes from generating custom dispatch methods depending on the set of signatures that were registered. If you can avoid looping over `*args`, you're basically halving your overhead. Regarding dispatch on `Literal`, ovld also generates custom dispatch methods that unroll a series of specific if/else statements, which is the only way you'll ever get spitting distance from a normal implementation.
 
-I haven't benchmarked the overhead of registering and compiling the methods, nor cache miss resolves, but... yeah... I expect ovld will do pretty badly in that regard. That'll be the next big push, probably.
+I haven't benchmarked the overhead of registering and compiling the methods, nor cache miss resolves, but I expect ovld will do pretty badly in that regard. That'll be the next big push, probably.

--- a/src/ovld/__init__.py
+++ b/src/ovld/__init__.py
@@ -4,7 +4,6 @@ from . import abc  # noqa: F401
 from .core import (
     Ovld,
     OvldBase,
-    OvldCall,
     OvldMC,
     extend_super,
     is_ovld,
@@ -53,7 +52,6 @@ __all__ = [
     "MultiTypeMap",
     "Ovld",
     "OvldBase",
-    "OvldCall",
     "OvldMC",
     "TypeMap",
     "extend_super",

--- a/src/ovld/core.py
+++ b/src/ovld/core.py
@@ -324,8 +324,7 @@ class _Ovld:
 
     @property
     def __doc__(self):
-        if not self._compiled:
-            self.compile()
+        self.ensure_compiled()
 
         docs = [fn.__doc__ for fn in self.defns.values() if fn.__doc__]
         if len(docs) == 1:
@@ -348,8 +347,7 @@ class _Ovld:
 
     @property
     def __signature__(self):
-        if not self._compiled:
-            self.compile()
+        self.ensure_compiled()
 
         sig = inspect.signature(self._dispatch)
         if not self.argument_analysis.is_method:
@@ -413,6 +411,10 @@ class _Ovld:
             return rename_function(fn, f"{self.__name__}.{fn.rename}")
         else:
             return fn
+
+    def ensure_compiled(self):
+        if not self._compiled:
+            self.compile()
 
     def compile(self):
         """Finalize this overload.
@@ -553,12 +555,6 @@ class _Ovld:
         return rval
 
     @_compile_first
-    def __getitem__(self, t):
-        if not isinstance(t, tuple):
-            t = (t,)
-        return self.map[t]
-
-    @_compile_first
     @_setattrs(rename="dispatch")
     def __call__(self, *args):  # pragma: no cover
         """Call the overloaded function.
@@ -569,7 +565,6 @@ class _Ovld:
         method = self.map[key]
         return method(*args)
 
-    @_compile_first
     @_setattrs(rename="next")
     def next(self, *args):
         """Call the next matching method after the caller, in terms of priority or specificity."""
@@ -581,12 +576,12 @@ class _Ovld:
     def __repr__(self):
         return f"<Ovld {self.name or hex(id(self))}>"
 
-    @_compile_first
     def display_methods(self):
+        self.ensure_compiled()
         self.map.display_methods()
 
-    @_compile_first
     def display_resolution(self, *args, **kwargs):
+        self.ensure_compiled()
         self.map.display_resolution(*args, **kwargs)
 
 

--- a/src/ovld/core.py
+++ b/src/ovld/core.py
@@ -380,9 +380,7 @@ class Ovld:
         self.name = name
         self.shortname = shortname or name
         self.__name__ = shortname
-        self.dispatch = bootstrap_dispatch(
-            self, name=f"{self.shortname}.dispatch"
-        )
+        self.dispatch = bootstrap_dispatch(self, name=self.shortname)
 
     def _set_attrs_from(self, fn):
         """Inherit relevant attributes from the function."""
@@ -422,12 +420,8 @@ class Ovld:
 
         dispatch = generate_dispatch(self, anal)
         if not hasattr(self, "dispatch"):
-            self.dispatch = bootstrap_dispatch(
-                self, name=f"{self.shortname}.dispatch"
-            )
-        self.dispatch.__code__ = rename_code(
-            dispatch.__code__, f"{self.shortname}.dispatch"
-        )
+            self.dispatch = bootstrap_dispatch(self, name=self.shortname)
+        self.dispatch.__code__ = rename_code(dispatch.__code__, self.shortname)
         self.dispatch.__kwdefaults__ = dispatch.__kwdefaults__
         self.dispatch.__annotations__ = dispatch.__annotations__
         self.dispatch.__defaults__ = dispatch.__defaults__

--- a/src/ovld/recode.py
+++ b/src/ovld/recode.py
@@ -485,7 +485,7 @@ def adapt_function(fn, ovld, newname):
     rec_syms = list(
         _search_names(
             fn.__code__,
-            (recurse, ovld, ovld._dispatch2),
+            (recurse, ovld, ovld.dispatch),
             fn.__globals__,
             fn.__closure__,
         )

--- a/src/ovld/recode.py
+++ b/src/ovld/recode.py
@@ -30,7 +30,7 @@ return method({posargs})
 
 
 def instantiate_code(symbol, code, inject={}):
-    virtual_file = f"<ovld{hash(code)}>"
+    virtual_file = f"<ovld:{abs(hash(code)):x}>"
     linecache.cache[virtual_file] = (None, None, splitlines(code), virtual_file)
     code = compile(source=code, filename=virtual_file, mode="exec")
     glb = {**inject}

--- a/src/ovld/recode.py
+++ b/src/ovld/recode.py
@@ -48,8 +48,8 @@ def __WRAP_DISPATCH__(OVLD):
 
 
 call_template = """
-method = OVLD.map[({lookup})]
-return method({posargs})
+{mvar} = OVLD.map[({lookup})]
+return {mvar}({posargs})
 """
 
 
@@ -88,6 +88,8 @@ def generate_dispatch(ov, arganal):
 
     for name in spr + spo + pr + po + kr:
         ndb.register(name)
+
+    mv = ndb.gensym(desired_name="method")
 
     for name in spr + spo:
         if name in spr:
@@ -141,6 +143,7 @@ def generate_dispatch(ov, arganal):
     fullcall = call_template.format(
         lookup=join(lookup, trail=True),
         posargs=join(posargs),
+        mvar=mv,
     )
 
     calls = []
@@ -150,6 +153,7 @@ def generate_dispatch(ov, arganal):
             call = call_template.format(
                 lookup=join(lookup[: req + i], trail=True),
                 posargs=join(posargs[: req + i + 1]),
+                mvar=mv,
             )
             call = textwrap.indent(call, "        ")
             calls.append(f"\nif {arg} is MISSING:{call}")

--- a/src/ovld/recode.py
+++ b/src/ovld/recode.py
@@ -61,7 +61,14 @@ def generate_dispatch(ov, arganal):
             rval += ","
         return rval
 
-    spr, spo, pr, po, kr, ko = arganal.compile()
+    arganal.compile()
+
+    spr = arganal.strict_positional_required
+    spo = arganal.strict_positional_optional
+    pr = arganal.positional_required
+    po = arganal.positional_optional
+    kr = arganal.keyword_required
+    ko = arganal.keyword_optional
 
     inits = set()
 

--- a/src/ovld/recode.py
+++ b/src/ovld/recode.py
@@ -1,14 +1,13 @@
 import ast
 import inspect
 import linecache
-import re
 import textwrap
 from ast import _splitlines_no_ff as splitlines
 from functools import reduce
 from itertools import count
 from types import CodeType, FunctionType
 
-from .utils import MISSING, Unusable, UsageError, subtler_type
+from .utils import MISSING, NameDatabase, Unusable, UsageError, subtler_type
 
 recurse = Unusable(
     "recurse() can only be used from inside an @ovld-registered function."
@@ -49,35 +48,6 @@ def instantiate_code(symbol, code, inject={}):
 #     rval = glb[symbol]
 #     rval.__globals__.update(inject)
 #     return rval
-
-
-class NameDatabase:
-    def __init__(self, default_name):
-        self.default_name = default_name
-        self.count = count()
-        self.variables = {}
-        self.names = {}
-        self.registered = set()
-
-    def register(self, name):
-        self.registered.add(name)
-
-    def __getitem__(self, value):
-        if isinstance(value, (int, float, str)):
-            return repr(value)
-        if id(value) in self.names:
-            return self.names[id(value)]
-        name = orig_name = getattr(value, "__name__", self.default_name)
-        if not re.match(string=name, pattern=r"[a-zA-Z_][a-zA-Z0-9_]+"):
-            name = self.default_name
-        i = 1
-        while name in self.registered:
-            name = f"{orig_name}{i}"
-            i += 1
-        self.variables[name] = value
-        self.names[id(value)] = name
-        self.registered.add(name)
-        return name
 
 
 def generate_dispatch(arganal):

--- a/tests/test_dependent.py
+++ b/tests/test_dependent.py
@@ -129,6 +129,10 @@ def test_dependent_ambiguity():
         f("hello")
 
 
+def test_regexp_isinstance():
+    assert isinstance("hello", Regexp[r"[ehl]+"])
+
+
 def test_regexp():
     @ovld
     def f(s: Regexp[r"hell+o"]):

--- a/tests/test_ovld.py
+++ b/tests/test_ovld.py
@@ -72,21 +72,6 @@ def test_nargs():
     assert f(0, 0, 0) == 3
 
 
-def test_getitem():
-    o = Ovld(name="f")
-
-    @o.register
-    def f(x: int):
-        return "int"
-
-    @o.register  # noqa: F811
-    def f(x: float):
-        return "float"
-
-    assert f[int].__name__ == "f[int]"
-    assert f[float].__name__ == "f[float]"
-
-
 def test_multimethod():
     o = Ovld()
 
@@ -1167,10 +1152,10 @@ def test_conform():
     f.register(intf)
     assert f([-2, -1, 0, 1, 2, 3]) == [4, 1, 0, 1, 4, 9]
 
-    f[int]._conformer.__conform__(intf2)
+    f.map[(int,)]._conformer.__conform__(intf2)
     assert f([-2, -1, 0, 1, 2, 3]) == [0, 0, 0, 1, 4, 9]
 
-    f[int]._conformer.__conform__(None)
+    f.map[(int,)]._conformer.__conform__(None)
     with pytest.raises(TypeError):
         f([-2, -1, 0, 1, 2, 3])
 
@@ -1192,7 +1177,7 @@ def test_conform_2():
     with pytest.raises(TypeError):
         f([-2.0, 5.5])
 
-    f[int]._conformer.__conform__(floatf)
+    f.map[(int,)]._conformer.__conform__(floatf)
 
     with pytest.raises(TypeError):
         f([-2, -1, 0, 1, 2, 3])

--- a/tests/test_ovld.py
+++ b/tests/test_ovld.py
@@ -1,3 +1,4 @@
+import inspect
 import re
 import sys
 import typing

--- a/tests/test_ovld.py
+++ b/tests/test_ovld.py
@@ -1639,6 +1639,9 @@ def test_doc(file_regression):
 
     file_regression.check(doc)
 
+    assert mushroom.__doc__ == mushroom.__ovld__.__doc__
+    assert mushroom.__signature__ == mushroom.__ovld__.__signature__
+
 
 def test_doc2(file_regression):
     @ovld

--- a/tests/test_ovld.py
+++ b/tests/test_ovld.py
@@ -1,4 +1,3 @@
-import inspect
 import re
 import sys
 import typing
@@ -10,7 +9,6 @@ from ovld import (
     Dataclass,
     Ovld,
     OvldBase,
-    OvldCall,
     OvldMC,
     call_next,
     extend_super,
@@ -147,7 +145,7 @@ def test_redefine_2():
 
 
 def test_redefine_parent():
-    o = Ovld(bootstrap=False)
+    o = Ovld()
     o2 = o.copy()
 
     @o.register
@@ -176,7 +174,7 @@ def test_redefine_parent():
 
 
 def test_redefine_parent_with_linkback():
-    o = Ovld(bootstrap=False)
+    o = Ovld()
     o2 = o.copy(linkback=True)
 
     @o.register
@@ -677,11 +675,6 @@ def test_variant():
     assert g([1, 2, "xxx", [3, 4]]) == [2, 3, "B", [4, 5]]
 
 
-class CustomCall(OvldCall):
-    def inc(self, x):
-        return x + 1
-
-
 def test_next():
     f = Ovld()
 
@@ -808,20 +801,6 @@ def test_resolve():
         return x * 2
 
     assert f.resolve(8)("hello") == "hellohello"
-
-
-def test_method_resolve():
-    class C(OvldBase):
-        def __init__(self, n):
-            self.n = n
-
-        @ovld
-        def f(self, x: int):
-            return x * self.n
-
-    c = C(2)
-
-    assert c.f.resolve(8)("hello") == "hellohello"
 
 
 def test_method():
@@ -985,7 +964,7 @@ def test_metaclass_dispatch():
 
         @ovld(priority=1000)
         def perform(self, x):
-            return self.perform.next(x) * 2
+            return call_next(x) * 2
 
         def perform(self, x: int):
             return x + self.n
@@ -1025,7 +1004,7 @@ def test_metaclass_dispatch_2():
         @extend_super
         @ovld(priority=1000)
         def perform(self, x):
-            return self.perform.next(x) * 2
+            return call_next(x) * 2
 
     x2 = Two(1)
     assert x2.perform([1, 2, 3]) == [4, 6, 8, 4, 6, 8]
@@ -1038,7 +1017,7 @@ def test_multiple_dispatch_3():
 
         @ovld(priority=1000)
         def perform(self, x):
-            return self.perform.next(x) * 2
+            return call_next(x) * 2
 
         def perform(self, xs: list):
             return [self.perform(x) for x in xs]

--- a/tests/test_ovld/test_method_doc.txt
+++ b/tests/test_ovld/test_method_doc.txt
@@ -1,4 +1,4 @@
-rise(self, /, x, y=MISSING, *, beauty=MISSING, bigness=MISSING)
+rise(x, y=MISSING, *, beauty=MISSING, bigness=MISSING)
 
 Unlike mushrooms, this function doesn't do anything.
 


### PR DESCRIPTION
By changing the dispatch function's code pointer, we can avoid going through `__call__` or a custom `__get__`, which leads to some performance gains, especially with methods.
