### PR TITLE
Fix compatibility with Python 3.15

### DIFF
--- a/src/ovld/core.py
+++ b/src/ovld/core.py
@@ -29,13 +29,13 @@ from .utils import (
 _orig_getdoc = inspect.getdoc
 
 
-def _getdoc(fn):
+def _getdoc(fn, **orig_kwargs):
     if hasattr(fn, "__calculate_doc__"):
         if inspect.ismethod(fn):
             fn = fn.__func__
         fn.__doc__ = fn.__calculate_doc__()
         del fn.__calculate_doc__
-    return _orig_getdoc(fn)
+    return _orig_getdoc(fn, **orig_kwargs)
 
 
 inspect.getdoc = _getdoc


### PR DESCRIPTION
Allow `inspect.getdoc` replacement to pass through keyword arguments.

See python/cpython#147952; reproduce the issue by using `help` at a REPL that has imported `ovld`.